### PR TITLE
Fix bug if client clock is slightly fast

### DIFF
--- a/simple_rest/auth/decorators.py
+++ b/simple_rest/auth/decorators.py
@@ -101,7 +101,17 @@ def validate_signature(request, secret_key):
         return False
 
     # Make sure the signature has not expired
-    delta = datetime.utcnow() - datetime.utcfromtimestamp(timestamp)
+    local_time = datetime.utcnow()
+    remote_time = datetime.utcfromtimestamp(timestamp)
+    
+    
+    # this stops a bug if the client clock is ever a little ahead of 
+    # the server clock.  Makes the window of acceptable time current +/- 5 mins
+    if local_time > remote_time:
+        delta = local_time - remote_time
+    else:   
+        delta = remote_time - local_time
+    
     if delta.seconds > 5 * 60:  # If the signature is older than 5 minutes, it's invalid
         return False
 


### PR DESCRIPTION
Allow timestamps to be in a 5 minute window around the server time.